### PR TITLE
Add funding.yml

### DIFF
--- a/funding.yml
+++ b/funding.yml
@@ -1,0 +1,1 @@
+open_collective: portal-2-community-edition


### PR DESCRIPTION
Since P2CE now has an Open Collective, it might be appropriate to display it in this repository. This simply adds a `funding.yml` file that links to the new Open Collective page.

If I'm not mistaken, Sponsorships need to be enabled in the repo settings for this to show.