### PR TITLE
Fix: remove "render: markdown" from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,14 +9,12 @@ body:
     description: A clear description of what the bug is. Feel free to add pictures or videos (They really help!)
     placeholder: |
       When I do X then Y happens.
-    render: markdown
   validations:
     required: true
 - type: textarea
   attributes:
     label: To Reproduce
-    description: Steps to reproduce the behavior&#58;
-    render: markdown
+    description: Steps to reproduce the behavior
     placeholder: |
       1. Open map ...
       2. Do ...
@@ -27,7 +25,6 @@ body:
   attributes:
     label: Expected Behavior
     description: A clear and concise description of what you expected to happen.
-    render: markdown
     placeholder: |
       When I do X then Z should happen.
   validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -13,7 +13,6 @@ body:
   attributes:
     label: Describe your suggestion
     description: Give a clear explanation of what you want us to add. Feel free to add pictures or video!
-    render: markdown
     placeholder: |
       Please don't give vague suggestions like "Make button look better" or "Add entity that damages the player".
       Think, how does it work. What are the inputs. What is the expected outcome?
@@ -24,7 +23,6 @@ body:
   attributes:
     label: Expected result
     description: Describe how the end result should look like and work.
-    render: markdown
     placeholder: |
       When I do X I want Y to happen.
   validations:

--- a/.github/ISSUE_TEMPLATE/portal-2-bug.yml
+++ b/.github/ISSUE_TEMPLATE/portal-2-bug.yml
@@ -9,14 +9,12 @@ body:
     description: A clear description of what the bug is. Feel free to add pictures or videos (They really help!)
     placeholder: |
       When I do X then Y happens.
-    render: markdown
   validations:
     required: true
 - type: textarea
   attributes:
     label: To Reproduce
-    description: Steps to reproduce the behavior&#58;
-    render: markdown
+    description: Steps to reproduce the behavior
     placeholder: |
       1. Open map ...
       2. Do ...
@@ -27,7 +25,6 @@ body:
   attributes:
     label: Expected Behavior
     description: A clear and concise description of what you expected to happen.
-    render: markdown
     placeholder: |
       When I do X then Z should happen.
   validations:


### PR DESCRIPTION
I messed up when converting the issue templates to the new syntax, and added a property to the text input boxes that makes it harder to read them, type in them, and blocks the user from uploading files. This PR removes that property.