### PR TITLE
Remove redundant sections of the issue reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,14 +21,6 @@ body:
       3. See error
   validations:
     required: true
-- type: textarea
-  attributes:
-    label: Expected Behavior
-    description: A clear and concise description of what you expected to happen.
-    placeholder: |
-      When I do X then Z should happen.
-  validations:
-    required: true
 - type: input
   attributes:
     label: Operating System

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -19,11 +19,3 @@ body:
       Please discuss your request on [Discord](https://discord.gg/NcHSmgb) before submitting an issue!
   validations:
     required: true
-- type: textarea
-  attributes:
-    label: Expected result
-    description: Describe how the end result should look like and work.
-    placeholder: |
-      When I do X I want Y to happen.
-  validations:
-    required: true

--- a/.github/ISSUE_TEMPLATE/portal-2-bug.yml
+++ b/.github/ISSUE_TEMPLATE/portal-2-bug.yml
@@ -21,14 +21,6 @@ body:
       3. See error
   validations:
     required: true
-- type: textarea
-  attributes:
-    label: Expected Behavior
-    description: A clear and concise description of what you expected to happen.
-    placeholder: |
-      When I do X then Z should happen.
-  validations:
-    required: true
 - type: input
   attributes:
     label: Operating System


### PR DESCRIPTION
Got rid of the "Expected behavior" sections because they're redundant and never properly used. 